### PR TITLE
Fixed new events number counting

### DIFF
--- a/src/SymfonyLive/Infrastructure/Doctrine/Returns.php
+++ b/src/SymfonyLive/Infrastructure/Doctrine/Returns.php
@@ -54,6 +54,6 @@ class Returns implements \SymfonyLive\Pos\Returns\Returns
     {
         $numberOfExistingEvents = count($return->getEvents()) - count($return->getNewEvents());
 
-        return range($numberOfExistingEvents, count($return->getEvents()));
+        return array_filter(range($numberOfExistingEvents, count($return->getEvents())));
     }
 }


### PR DESCRIPTION
If you have one event only, this function returns a two-element array `[0 , 1]` which causes double events to be persisted. 

example:

```
events = 1
newEvents = 1
numberOfExistingEvents = 0
returns = [0, 1]
```

I think it should skip the 0 counter in the range array.
